### PR TITLE
Refactor Trainer arguments, replacing gpus with devices and accelerator

### DIFF
--- a/genie/train.py
+++ b/genie/train.py
@@ -42,7 +42,8 @@ def main(args):
 
 	# trainer
 	trainer = Trainer(
-		gpus=gpus,
+		devices=gpus,
+		accelerator='gpu',
 		logger=[tb_logger, wandb_logger],
 		strategy='ddp',
 		deterministic=True,


### PR DESCRIPTION
This commit updates the arguments provided to Trainer in train.py to be compatible with the current PyTorch Lightning version. The gpus keyword argument is now replaced with devices and accelerator.